### PR TITLE
Add missing multiplayer keywords

### DIFF
--- a/godot-gdscript.el
+++ b/godot-gdscript.el
@@ -154,7 +154,9 @@
   (defconst godot-gdscript-rx-constituents
     `((block-start          . ,(rx symbol-start
                                    (or "class" "elif" "else" "except" "finally" "for"
-                                       "func" "if" "try" "while" "with")
+                                       "func" "if" "try" "while" "with"
+                                       ;; Multiplayer stuff
+                                       "puppet" "master" "remote" "remotesync")
                                    symbol-end))
       (dedenter            . ,(rx symbol-start
                                   (or "elif" "else" "except" "finally")
@@ -163,7 +165,8 @@
                                   (or
                                    "break" "continue" "pass" "raise" "return")
                                   symbol-end))
-      (decorator            . ,(rx line-start (* space) ?@ (any letter ?_)
+      (decorator            . ,(rx line-start
+                                   (* space) ?@ (any letter ?_)
                                    (* (any word ?_))))
       (defun                . ,(rx symbol-start (or "func" "class") symbol-end))
       (if-name-main         . ,(rx line-start "if" (+ space) "__name__"
@@ -288,6 +291,8 @@ The type returned can be `comment', `string' or `paren'."
           "assert" "break" "breakpoint" "class" "const" "continue"
           "default" "do" "elif" "else" "enum"
           "export" "extends" "for" "func" "if" "onready"
+          ;; Multiplayer stuff
+          "puppet" "master" "remote" "remotesync"
           "pass" "preload" "resume" "return" "setget"
           "signal" "static" "tool" "var" "while" "yield")
          symbol-end)


### PR DESCRIPTION
After working through the multiplayer [tutorial](https://docs.godotengine.org/en/3.1/tutorials/networking/high_level_multiplayer.html) it seems like some of the gdscript keywords specific to multiplayer are missing.

This PR fixes the issue, although I'm not sure if this is the correct way to go about it?

![image](https://user-images.githubusercontent.com/100964/54493283-93cca200-4900-11e9-847b-4491b0c4671b.png)
